### PR TITLE
Added basic autocomplete for image names

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,8 @@ Where `{IMAGE_NAME}` is one of the images listed below and `{DEVICE_PATH}` is th
 
 ## Parameters
 
-There is a single parameter the tool can take:
-
     -l or --list-images		List out all the images
+    --porcelain                 Optimise output so it can be fed into other programs
 
 ## Supported Images
 
@@ -52,3 +51,7 @@ There is only a single package required which is non-standard; pv. It's easily i
     
     # RHEL / CentOS
     yum install pv
+
+## Autocomplete
+
+If you want to allow autocompletion with the image names, add the contents of `autocomplete` to your `.bashrc` file

--- a/autocomplete
+++ b/autocomplete
@@ -1,0 +1,14 @@
+# zsh support
+if [[ -n ${ZSH_VERSION-} ]]; then
+    autoload -U +X bashcompinit && bashcompinit
+fi
+
+# Autocompletion for image names
+_complete_images() {
+    local cur prev
+    COMPREPLY=()
+    cur=${COMP_WORDS[COMP_CWORD]}
+    prev=${COMP_WORDS[COMP_CWORD-1]}
+    COMPREPLY=( $(compgen -W "$(./manager.sh --list-images --porcelain)" -- $cur) )
+}
+complete -F _complete_images manager.sh

--- a/manager.sh
+++ b/manager.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-echo "-----------------------------------------"
-echo " Raspberry Pi Image Manager (RIM) v0.3.2 "
-echo "-----------------------------------------"
-
 # Get the source directory
 DIR="${BASH_SOURCE%/*}"
 if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
@@ -17,15 +13,23 @@ LIBRARY_PATH_ROOT="$DIR/utils"
 
 # Set default options
 IMAGE_LIST=false
+PORCELAIN=false
 
 # Get any params defined
 for i in "$@"
 do
 case $i in
         -l|--list-images)	IMAGE_LIST=true ;;
+        --porcelain)    	PORCELAIN=true ;;
         -*)					echo "UNKNOWN PARAMETER ${i#*=}"; exit ;;
 esac
 done
+
+if [ $PORCELAIN = false ]; then
+    echo "-----------------------------------------"
+    echo " Raspberry Pi Image Manager (RIM) v0.3.2 "
+    echo "-----------------------------------------"
+fi
 
 declare -A Images
 
@@ -44,10 +48,16 @@ Images['RetroPi']="http://downloads.petrockblock.com/images/retropie-v3.2.1-rpi1
 
 # If the list flag has been raised, list the images
 if [ $IMAGE_LIST = true ]; then
-	echo "Images:"
+        if [ $PORCELAIN = false ]; then
+            echo "Images:"
+        fi
 	for i in "${!Images[@]}"
 	do
-		echo -e "- $COLOUR_PUR$i$COLOUR_RST"
+                if [ $PORCELAIN = true ]; then
+                   echo -e "$i"
+                else
+                    echo -e "- $COLOUR_PUR$i$COLOUR_RST"
+                fi
 	done
 	exit
 fi


### PR DESCRIPTION
I've started adding autocomplete functionality. It autocompletes the image names if you hit tab while adding the arguments. See the bottom of the readme on how to install.

It works! But it's not perfect, here's the current issues:
- [ ] There needs to be a better way of installing the autocompletion than copying code into .bashrc
- [ ] It currently autocompletes and shows the image names for any of the arguments, not just the first arg
