### PR TITLE
Adds support for other hashing algorithms

### DIFF
--- a/utils/hashCheck.sh
+++ b/utils/hashCheck.sh
@@ -2,10 +2,28 @@
 function checkImageHash() {
 
     local imageFilePath="$1"
-    local imageHashCompare="$2"
+    local imageHashFile="$2"
+
+    local algorithm="sha1sum"
+    local algorithmName="SHA1"
+    local imageHashCompare=$imageHashFile
+
+    if [[ "$imageHashFile" =~ sha256:(.*)\n? ]]; then
+      algorithmName="SHA256"
+      algorithm="sha256sum"
+      imageHashCompare=`echo ${BASH_REMATCH[1]}`
+    elif [[ "$imageHashFile" =~ sha1:(.*)\n? ]]; then
+      algorithmName="SHA1"
+      algorithm="sha1sum"
+      imageHashCompare=`echo ${BASH_REMATCH[1]}`
+    elif [[ "$imageHashFile" =~ md5:(.*)\n? ]]; then
+      algorithmName="MD5"
+      algorithm="md5sum"
+      imageHashCompare=`echo ${BASH_REMATCH[1]}`
+    fi
 
     # Hash the downloaded image
-    local IMAGE_HASH_ACTUAL=$(pv -paeWcN "Checking Hash (SHA1)" "$imageFilePath" | sha1sum |  grep -Eo "^([^ ]+)")
+    local IMAGE_HASH_ACTUAL=$(pv -paeWcN "Checking Hash ($algorithmName)" "$imageFilePath" | $algorithm |  grep -Eo "^([^ ]+)")
 
     # Check the hashes match
     if [ "$imageHashCompare" != "$IMAGE_HASH_ACTUAL" ]; then


### PR DESCRIPTION
I've added support for these hashing algorithms: `md5`, `sha1`, `sha256`

Largely resolves #21 , apart from that you can only use one algorithm per image.

I had a go at trying to get multiple algorithms to work, however I haven't been able to get the multi-line regexes working well yet. 